### PR TITLE
feature/added fail-fast cli option

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    types: [opened, reopened, synchronize]
 
 jobs:
   analyze:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
       - [Markdown Example](#markdown-example)
       - [Raw CSV Example](#raw-csv-example)
   - [Output Control](#output-control)
+  - [Other Features](#other-features)
   - [Shell Completion Scripts](#shell-completion-scripts)
   - [Alternatives](#alternatives)
 
@@ -48,6 +49,7 @@
 - Accumulate results for different runs and compare them later
 - Set the number of times every scenario is executed
 - Choose between alternate executions and sequential execution of the same command
+- Fail-fast to exit immediately when a benchmark error is reported
 - Save results in `txt`, `json`, `csv`, `csv/raw`, `md` and `md/raw` formats
 - Control your benchmark environment
   - Set optional working directory per scenario and/or command 
@@ -319,6 +321,10 @@ However, there are several ways you can control what is logged and in what level
 - `--pipe-stdout` and `--pipe-stderr` - pipe the standard out and err of executed benchmark commands respectively, to standard err.
 - `--silent` or `-s` - sets the logging level to the lowest level possible, which includes only fatal errors. That is a softer version of `2>/dev/null` and should be preferred in general.
 - `--debug` or `-d` - sets the logging level to the highest possible level, for troubleshooting.
+
+## Other Features
+- `--alternate` - when combined with multiple commands, `bert` uses alternate scenario execution instead of executing scenarios one after another.
+- `--fail-fast` - tells `bert` to exit immediately when a benchmark error is reported. This is handy for reproducing illusive errors using brute-force.
 
 ## Shell Completion Scripts
 `bert` comes with completion scripts for `zsh`, `bash`, `fish` and `PowerShell`. When installed with [brew](#install-from-a-homebrew-tap) completions scripts are automatically installed to the appropriate location, otherwise the scripts can be found in the tar-ball version of the released binaries.

--- a/api/spec.go
+++ b/api/spec.go
@@ -23,7 +23,7 @@ type BenchmarkSpec struct {
 	Scenarios  []ScenarioSpec `json:"scenarios" yaml:"scenarios" validate:"required,min=1"`
 	Executions int            `validate:"required,gte=1"`
 	Alternate  bool           `json:"alternate,omitempty" yaml:"alternate,omitempty"`
-	FailFast  bool            `json:"failFast,omitempty" yaml:"failFast,omitempty"`
+	FailFast   bool           `json:"failFast,omitempty" yaml:"failFast,omitempty"`
 }
 
 // ID returns a unique identifier

--- a/api/spec.go
+++ b/api/spec.go
@@ -23,6 +23,7 @@ type BenchmarkSpec struct {
 	Scenarios  []ScenarioSpec `json:"scenarios" yaml:"scenarios" validate:"required,min=1"`
 	Executions int            `validate:"required,gte=1"`
 	Alternate  bool           `json:"alternate,omitempty" yaml:"alternate,omitempty"`
+	FailFast  bool            `json:"failFast,omitempty" yaml:"failFast,omitempty"`
 }
 
 // ID returns a unique identifier

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,6 +66,10 @@ func handlePanics(exitFn func(int)) {
 			log.Fatal(err)
 			exitFn(1)
 		}
+		if err, ok := o.(cli.ExecutionAbortedError); ok {
+			log.Error(err)
+			exitFn(0)
+		}
 
 		issueURL := errorhandling.GenerateGitHubCreateNewIssueURL(
 			"sha1n",

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -10,14 +10,43 @@ import (
 
 func TestExitCodeWithMissingRequiredArguments(t *testing.T) {
 	expectedPanicExitCode := 1
-	actualExitcode := 0
+	actualExitCode := 0
 
 	os.Args = []string{}
 	doRun(func(i int) {
-		actualExitcode = i
+		actualExitCode = i
 	})
 
-	assert.Equal(t, expectedPanicExitCode, actualExitcode)
+	assert.Equal(t, expectedPanicExitCode, actualExitCode)
+}
+
+func TestExitCodeWithFailFastAndCommandFailure(t *testing.T) {
+	var (
+		actualExitCode int
+		hasValue       bool
+	)
+
+	testWith(
+		t,
+		[]string{
+			"program",
+			"-e",
+			"1",
+			"-k",
+			"'<non-existent-command>'",
+		},
+		true,
+		func(t *testing.T) {
+			doRun(func(code int) {
+				if !hasValue {
+					actualExitCode = code
+					hasValue = true
+				}
+			})
+		},
+	)
+
+	assert.Equal(t, 0, actualExitCode)
 }
 
 func TestSanity(t *testing.T) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@
       - [Markdown Example](#markdown-example)
       - [Raw CSV Example](#raw-csv-example)
   - [Output Control](#output-control)
+  - [Other Features](#other-features)
   - [Shell Completion Scripts](#shell-completion-scripts)
   - [Alternatives](#alternatives)
 
@@ -48,6 +49,7 @@
 - Accumulate results for different runs and compare them later
 - Set the number of times every scenario is executed
 - Choose between alternate executions and sequential execution of the same command
+- Fail-fast to exit immediately when a benchmark error is reported
 - Save results in `txt`, `json`, `csv`, `csv/raw`, `md` and `md/raw` formats
 - Control your benchmark environment
   - Set optional working directory per scenario and/or command 
@@ -319,6 +321,10 @@ However, there are several ways you can control what is logged and in what level
 - `--pipe-stdout` and `--pipe-stderr` - pipe the standard out and err of executed benchmark commands respectively, to standard err.
 - `--silent` or `-s` - sets the logging level to the lowest level possible, which includes only fatal errors. That is a softer version of `2>/dev/null` and should be preferred in general.
 - `--debug` or `-d` - sets the logging level to the highest possible level, for troubleshooting.
+
+## Other Features
+- `--alternate` - when combined with multiple commands, `bert` uses alternate scenario execution instead of executing scenarios one after another.
+- `--fail-fast` - tells `bert` to exit immediately when a benchmark error is reported. This is handy for reproducing illusive errors using brute-force.
 
 ## Shell Completion Scripts
 `bert` comes with completion scripts for `zsh`, `bash`, `fish` and `PowerShell`. When installed with [brew](#install-from-a-homebrew-tap) completions scripts are automatically installed to the appropriate location, otherwise the scripts can be found in the tar-ball version of the released binaries.

--- a/internal/cli/abortion_listener.go
+++ b/internal/cli/abortion_listener.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/sha1n/bert/api"
+)
+
+// ExecutionAbortedError a marker type for fatal user errors.
+// This type of errors is treated differently when user feedback is provided.
+type ExecutionAbortedError struct {
+	message string
+}
+
+func (e ExecutionAbortedError) Error() string {
+	return e.message
+}
+
+// NewExecutionAbortedError creates a new abortion error with the specified message.
+func NewExecutionAbortedError(id api.ID, err error) ExecutionAbortedError {
+	return ExecutionAbortedError{
+		message: fmt.Sprintf("'%s' reported an error. %s", id, err),
+	}
+}
+
+type failFastListener struct {
+	api.Listener
+}
+
+// NewFailFastListener creates a new listener that logs abortion events.
+func NewFailFastListener(delegate api.Listener) api.Listener {
+	return &failFastListener{Listener: delegate}
+}
+
+// OnError logs an error message with the specified ID and error details
+func (l failFastListener) OnError(id api.ID, err error) {
+	panic(NewExecutionAbortedError(id, err))
+}

--- a/internal/cli/abortion_listener_test.go
+++ b/internal/cli/abortion_listener_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sha1n/bert/api"
+)
+
+func TestFailFastListener_OnError(t *testing.T) {
+	mockID := api.ID("mockID")
+	mockError := errors.New("mock error")
+
+	failFastListener := NewFailFastListener(&mockListener{})
+
+	defer func() {
+		actual := recover()
+		if actual == nil {
+			t.Errorf("The code did not panic")
+		}
+		
+		_, ok := actual.(ExecutionAbortedError)
+		if !ok {
+			t.Errorf("Unexpected panic type: %T", actual)
+		}
+	}()
+
+	failFastListener.OnError(mockID, mockError)
+}
+
+type mockListener struct{}
+
+// OnBenchmarkEnd implements api.Listener.
+func (*mockListener) OnBenchmarkEnd() {
+	panic("unimplemented")
+}
+
+// OnBenchmarkStart implements api.Listener.
+func (*mockListener) OnBenchmarkStart() {
+	panic("unimplemented")
+}
+
+// OnMessage implements api.Listener.
+func (*mockListener) OnMessage(id string, message string) {
+	panic("unimplemented")
+}
+
+// OnMessagef implements api.Listener.
+func (*mockListener) OnMessagef(id string, format string, args ...interface{}) {
+	panic("unimplemented")
+}
+
+// OnScenarioEnd implements api.Listener.
+func (*mockListener) OnScenarioEnd(id string) {
+	panic("unimplemented")
+}
+
+// OnScenarioStart implements api.Listener.
+func (*mockListener) OnScenarioStart(id string) {
+	panic("unimplemented")
+}
+
+func (m *mockListener) OnError(id api.ID, err error) {}

--- a/internal/cli/abortion_listener_test.go
+++ b/internal/cli/abortion_listener_test.go
@@ -18,7 +18,7 @@ func TestFailFastListener_OnError(t *testing.T) {
 		if actual == nil {
 			t.Errorf("The code did not panic")
 		}
-		
+
 		_, ok := actual.(ExecutionAbortedError)
 		if !ok {
 			t.Errorf("Unexpected panic type: %T", actual)

--- a/internal/cli/args.go
+++ b/internal/cli/args.go
@@ -18,6 +18,8 @@ const (
 	ArgNameExecutions = "executions"
 	// ArgNameAlternate : program arg name
 	ArgNameAlternate = "alternate"
+	// ArgNameFailFast : program arg name
+	ArgNameFailFast = "fail-fast"
 	// ArgNameOutputFile : program arg name
 	ArgNameOutputFile = "out-file"
 	// ArgNameConfigExample : program arg name

--- a/internal/cli/args.go
+++ b/internal/cli/args.go
@@ -138,7 +138,8 @@ func GetConfigFilePath(cmd *cobra.Command) string {
 
 	// Experimental: look for a dot-file if no config has been specified
 	if err != nil || configPath == "" {
-		wd, err := os.Getwd()
+		var wd string
+		wd, err = os.Getwd()
 
 		if err == nil {
 			configPath = path.Join(wd, DirectoryConfigFileName)

--- a/internal/cli/fatal.go
+++ b/internal/cli/fatal.go
@@ -27,7 +27,7 @@ type CheckFatalFn = func(error)
 // CheckBenchmarkInitFatal checks the specified error and treats it as fatal if not nil
 func CheckBenchmarkInitFatal(err error) {
 	if err != nil {
-		panic(NewFatalUserErrorf("Failed to initialize benchark. Error: %s", err.Error()))
+		panic(NewFatalUserErrorf("Failed to initialize benchmark. Error: %s", err.Error()))
 	}
 }
 

--- a/internal/cli/main_runner_test.go
+++ b/internal/cli/main_runner_test.go
@@ -146,6 +146,7 @@ func Test_loadSpecFromPositionalArguments(t *testing.T) {
 	expectedValidSpec, _ := specs.CreateSpecFrom(
 		expectedExecutions,
 		true,
+		false,
 		api.CommandSpec{Cmd: []string{"cmd", "-a"}},
 		api.CommandSpec{Cmd: []string{"cmd", "-b"}},
 		api.CommandSpec{Cmd: []string{"cmd", "a string"}},

--- a/pkg/specs/spec.go
+++ b/pkg/specs/spec.go
@@ -39,7 +39,7 @@ func LoadSpec(path string) (api.BenchmarkSpec, error) {
 // CreateSpecFrom creates a spec from the specified parameters.
 //
 // Returns an error if the specified 'executions' is non-positive.
-func CreateSpecFrom(executions int, alternate bool, commands ...api.CommandSpec) (spec api.BenchmarkSpec, err error) {
+func CreateSpecFrom(executions int, alternate bool, failFast bool, commands ...api.CommandSpec) (spec api.BenchmarkSpec, err error) {
 	if executions < 1 {
 		return spec, errors.New("executions must be positive")
 	}
@@ -47,6 +47,7 @@ func CreateSpecFrom(executions int, alternate bool, commands ...api.CommandSpec)
 	spec = api.BenchmarkSpec{
 		Executions: executions,
 		Alternate:  alternate,
+		FailFast:   failFast,
 		Scenarios:  []api.ScenarioSpec{},
 	}
 

--- a/pkg/specs/spec_test.go
+++ b/pkg/specs/spec_test.go
@@ -127,6 +127,7 @@ func TestCreateSpecFrom(t *testing.T) {
 	type args struct {
 		executions int
 		alternate  bool
+		failFast  bool
 		commands   []api.CommandSpec
 	}
 	tests := []struct {
@@ -137,26 +138,26 @@ func TestCreateSpecFrom(t *testing.T) {
 	}{
 		{
 			name:     "valid alternate",
-			args:     args{executions: 1, alternate: true, commands: []api.CommandSpec{{Cmd: []string{"ls", "-l"}}}},
-			wantSpec: api.BenchmarkSpec{Executions: 1, Alternate: true, Scenarios: []api.ScenarioSpec{{Name: "[ls -l]", Command: &api.CommandSpec{Cmd: []string{"ls", "-l"}}}}},
+			args:     args{executions: 1, alternate: true, failFast: true, commands: []api.CommandSpec{{Cmd: []string{"ls", "-l"}}}},
+			wantSpec: api.BenchmarkSpec{Executions: 1, Alternate: true, FailFast: true, Scenarios: []api.ScenarioSpec{{Name: "[ls -l]", Command: &api.CommandSpec{Cmd: []string{"ls", "-l"}}}}},
 			wantErr:  false,
 		},
 		{
 			name:     "valid dual command",
-			args:     args{executions: 1, alternate: false, commands: []api.CommandSpec{{Cmd: []string{"ls", "-l"}}, {Cmd: []string{"ls", "-a"}}}},
-			wantSpec: api.BenchmarkSpec{Executions: 1, Alternate: false, Scenarios: []api.ScenarioSpec{{Name: "[ls -l]", Command: &api.CommandSpec{Cmd: []string{"ls", "-l"}}}, {Name: "[ls -a]", Command: &api.CommandSpec{Cmd: []string{"ls", "-a"}}}}},
+			args:     args{executions: 1, alternate: false, failFast: true, commands: []api.CommandSpec{{Cmd: []string{"ls", "-l"}}, {Cmd: []string{"ls", "-a"}}}},
+			wantSpec: api.BenchmarkSpec{Executions: 1, Alternate: false, FailFast: true, Scenarios: []api.ScenarioSpec{{Name: "[ls -l]", Command: &api.CommandSpec{Cmd: []string{"ls", "-l"}}}, {Name: "[ls -a]", Command: &api.CommandSpec{Cmd: []string{"ls", "-a"}}}}},
 			wantErr:  false,
 		},
 		{
 			name:     "non-positive executions",
-			args:     args{executions: rand.Intn(10) * -1, alternate: false, commands: []api.CommandSpec{{Cmd: []string{"ls", "-l"}}}},
+			args:     args{executions: rand.Intn(10) * -1, alternate: false, failFast: true, commands: []api.CommandSpec{{Cmd: []string{"ls", "-l"}}}},
 			wantSpec: api.BenchmarkSpec{},
 			wantErr:  true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotSpec, err := CreateSpecFrom(tt.args.executions, tt.args.alternate, tt.args.commands...)
+			gotSpec, err := CreateSpecFrom(tt.args.executions, tt.args.alternate, tt.args.failFast, tt.args.commands...)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -180,6 +181,7 @@ func expectedBenchmarkSpec() api.BenchmarkSpec {
 	return api.BenchmarkSpec{
 		Executions: 10,
 		Alternate:  true,
+		FailFast: true,
 		Scenarios: []api.ScenarioSpec{
 			{
 				Name:             "scenario A",

--- a/pkg/specs/spec_test.go
+++ b/pkg/specs/spec_test.go
@@ -127,7 +127,7 @@ func TestCreateSpecFrom(t *testing.T) {
 	type args struct {
 		executions int
 		alternate  bool
-		failFast  bool
+		failFast   bool
 		commands   []api.CommandSpec
 	}
 	tests := []struct {
@@ -181,7 +181,7 @@ func expectedBenchmarkSpec() api.BenchmarkSpec {
 	return api.BenchmarkSpec{
 		Executions: 10,
 		Alternate:  true,
-		FailFast: true,
+		FailFast:   true,
 		Scenarios: []api.ScenarioSpec{
 			{
 				Name:             "scenario A",

--- a/test/data/spec_test_load.json
+++ b/test/data/spec_test_load.json
@@ -1,5 +1,6 @@
 {
   "alternate": true,
+  "failFast": true,
   "executions": 10,
   "scenarios": [
     {

--- a/test/data/spec_test_load.yaml
+++ b/test/data/spec_test_load.yaml
@@ -1,5 +1,6 @@
 ---
 alternate: true
+failFast: true
 executions: 10
 scenarios:
 - name: scenario A


### PR DESCRIPTION
This PR adds a new CLI flag `--fail-fast` / `k` which causes the program to exit immediately one a benchmark error is reported.

This feature is handy for brute-force reproduction of errors such as flaky tests, race condition related errors etc.

Example:
```bash
bert -e 10 'poetry run pytest tests/test_delay.py::test_delay' --pipe-stdout --fail-fast
```